### PR TITLE
Update requests library version to 2.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # runtime required deps
-requests==2.19.1
+requests==2.20.0
 
 # dev deps
 behave==1.2.6


### PR DESCRIPTION
CVE-2018-18074 More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0
The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.